### PR TITLE
Support for MM v4 firmware 202407211632

### DIFF
--- a/SD_CARD/App/EasyLogoTweak/flash_Logo.sh
+++ b/SD_CARD/App/EasyLogoTweak/flash_Logo.sh
@@ -19,7 +19,7 @@ if [ -f "/customer/app/axp_test" ]; then  # differenciate MM and MMP supported f
 	SUPPORTED_VERSION="202306282128"
 else
 	MODEL="MM"
-	SUPPORTED_VERSION="202310271401"
+	SUPPORTED_VERSION="202407211632"
 fi
 
 


### PR DESCRIPTION
String changed in flash_Logo.sh to allow the app to work on the latest v4 firmware.

[Confirmed working via video here](https://github.com/schmurtzm/Miyoo-Mini-easy-logotweak/issues/15)